### PR TITLE
Add support for indexing JSON collections

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/golistic/kolekto"
 	"github.com/golistic/kolekto/kolektor"
-	"github.com/golistic/kolekto/stores"
-
 	_ "github.com/golistic/kolekto/stores/dbpgsql" // register store
 )
 
@@ -32,7 +30,7 @@ func Example() {
 	// We assume the 'music' database exists.
 	dsn := "user=postgres password=postgres host=localhost dbname=music port=5438"
 
-	session, err := kolekto.NewSession(stores.PgSQL, dsn)
+	session, err := kolekto.NewSession(kolektor.PgSQL, dsn)
 	if err != nil {
 		fmt.Printf("Error: %s", err)
 		return

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/golistic/xstrings v0.0.0-20220526163930-92a29fd1bf54 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14j
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/golistic/xstrings v0.0.0-20220526163930-92a29fd1bf54 h1:j96coeq8rp28HG4F/VwrAuzNiktqMiW2GtXOnAdgIIw=
+github.com/golistic/xstrings v0.0.0-20220526163930-92a29fd1bf54/go.mod h1:0OequtLc+tesHgj1mgTpe+/nka4sVnfUO5IYmpxLPCc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/internal/ytest/mysql.go
+++ b/internal/ytest/mysql.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+//go:build !nomysql
+
+package ytest
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+func PrepareMySQL(dsn string) (string, error) {
+	config, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return "", err
+	}
+
+	dbName := config.DBName
+	config.DBName = ""
+	if config.Params == nil {
+		config.Params = map[string]string{}
+	}
+	config.Params["parseTime"] = "true"
+
+	db, err := sql.Open("mysql", config.FormatDSN())
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err = db.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName); err != nil {
+		return "", fmt.Errorf("mysql: %s", err)
+	}
+
+	if _, err = db.ExecContext(context.Background(), "CREATE DATABASE "+dbName); err != nil {
+		return "", err
+	}
+
+	config.DBName = dbName
+	return config.FormatDSN(), nil
+}

--- a/internal/ytest/pgsql.go
+++ b/internal/ytest/pgsql.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+//go:build !nopgsql
+
+package ytest
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
+)
+
+func PreparePostgreSQL(dsn string) (string, error) {
+	pgConfig, err := pgconn.ParseConfig(dsn)
+	if err != nil {
+		return "", err
+	}
+	if pgConfig.Database == "" {
+		return "", fmt.Errorf("database in DSN must not be empty")
+	}
+
+	baseDSN := strings.Replace(dsn, "/"+pgConfig.Database, "/postgres", -1)
+
+	conn, err := pgx.Connect(context.Background(), baseDSN)
+	if err != nil {
+		return "", err
+	}
+
+	if _, err = conn.Exec(context.Background(), "DROP DATABASE IF EXISTS "+pgConfig.Database); err != nil {
+		return "", fmt.Errorf("pgsql: %s", err)
+	}
+
+	if _, err = conn.Exec(context.Background(), "CREATE DATABASE "+pgConfig.Database); err != nil {
+		return "", err
+	}
+
+	return dsn, nil
+}

--- a/kolektor/kinds.go
+++ b/kolektor/kinds.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Geert JM Vanderkelen
 
-package stores
+package kolektor
 
 type StoreKind int
 

--- a/kolektor/storer.go
+++ b/kolektor/storer.go
@@ -11,3 +11,13 @@ type Storer interface {
 	RemoveCollection(model Modeler) error
 	InitCollection(model Modeler) error
 }
+
+type Indexer interface {
+	Indexes(kind StoreKind) []Index
+}
+
+type Index struct {
+	Name       string
+	Unique     bool
+	Expression string
+}

--- a/main_mysql_test.go
+++ b/main_mysql_test.go
@@ -5,45 +5,10 @@
 package kolekto
 
 import (
-	"context"
-	"database/sql"
-	"fmt"
-
-	"github.com/go-sql-driver/mysql"
-	"github.com/golistic/kolekto/stores"
+	"github.com/golistic/kolekto/internal/ytest"
+	"github.com/golistic/kolekto/kolektor"
 )
 
 func init() {
-	prepareStore[stores.MySQL] = prepareMySQL
-}
-
-func prepareMySQL(dsn string) error {
-	config, err := mysql.ParseDSN(dsn)
-	if err != nil {
-		return err
-	}
-	dbName := config.DBName
-	config.DBName = ""
-	if config.Params == nil {
-		config.Params = map[string]string{}
-	}
-	config.Params["parseTime"] = "true"
-
-	db, err := sql.Open("mysql", config.FormatDSN())
-	if err != nil {
-		return err
-	}
-	defer func() { _ = db.Close() }()
-
-	if _, err = db.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+dbName); err != nil {
-		return fmt.Errorf("mysql: %s", err)
-	}
-
-	if _, err = db.ExecContext(context.Background(), "CREATE DATABASE "+dbName); err != nil {
-		return err
-	}
-
-	config.DBName = dbName
-	testAllDSN[stores.MySQL] = config.FormatDSN()
-	return nil
+	prepareStore[kolektor.MySQL] = ytest.PrepareMySQL
 }

--- a/main_pgsql_test.go
+++ b/main_pgsql_test.go
@@ -5,43 +5,10 @@
 package kolekto
 
 import (
-	"context"
-	"fmt"
-	"strings"
-
-	"github.com/golistic/kolekto/stores"
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgx/v4"
+	"github.com/golistic/kolekto/internal/ytest"
+	"github.com/golistic/kolekto/kolektor"
 )
 
 func init() {
-	prepareStore[stores.PgSQL] = preparePostgreSQL
-}
-
-func preparePostgreSQL(dsn string) error {
-	pgConfig, err := pgconn.ParseConfig(dsn)
-	if testErr != nil {
-		return err
-	}
-	if pgConfig.Database == "" {
-		return fmt.Errorf("database in DSN must not be empty")
-	}
-
-	baseDSN := strings.Replace(dsn, "/"+pgConfig.Database, "/postgres", -1)
-
-	conn, err := pgx.Connect(context.Background(), baseDSN)
-	if err != nil {
-		return err
-	}
-
-	if _, err = conn.Exec(context.Background(), "DROP DATABASE IF EXISTS "+pgConfig.Database); err != nil {
-		return fmt.Errorf("pgsql: %s", err)
-	}
-
-	if _, err = conn.Exec(context.Background(), "CREATE DATABASE "+pgConfig.Database); err != nil {
-		return err
-	}
-
-	testAllDSN[stores.PgSQL] = dsn
-	return nil
+	prepareStore[kolektor.PgSQL] = ytest.PreparePostgreSQL
 }

--- a/main_test.go
+++ b/main_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/golistic/kolekto/stores"
+	"github.com/golistic/kolekto/kolektor"
 )
 
 // following defaults assume Docker containers are started using the
@@ -18,8 +18,8 @@ const defaultMySQLDSN = "root:mysql@tcp(localhost:3360)/kolekto_test"
 var (
 	testExitCode int
 	testErr      error
-	testAllDSN   = map[stores.StoreKind]string{}
-	prepareStore = map[stores.StoreKind]func(dsn string) error{}
+	testAllDSN   = map[kolektor.StoreKind]string{}
+	prepareStore = map[kolektor.StoreKind]func(dsn string) (string, error){}
 )
 
 func testTearDown() {
@@ -34,19 +34,20 @@ func TestMain(m *testing.M) {
 	defer testTearDown()
 
 	if v, have := os.LookupEnv("TEST_PGSQL_DSN"); have {
-		testAllDSN[stores.PgSQL] = v
+		testAllDSN[kolektor.PgSQL] = v
 	} else {
-		testAllDSN[stores.PgSQL] = defaultPgSQLDSN
+		testAllDSN[kolektor.PgSQL] = defaultPgSQLDSN
 	}
 
 	if v, have := os.LookupEnv("TEST_MYSQL_DSN"); have {
-		testAllDSN[stores.MySQL] = v
+		testAllDSN[kolektor.MySQL] = v
 	} else {
-		testAllDSN[stores.MySQL] = defaultMySQLDSN
+		testAllDSN[kolektor.MySQL] = defaultMySQLDSN
 	}
 
 	for kind, prep := range prepareStore {
-		if testErr = prep(testAllDSN[kind]); testErr != nil {
+		testAllDSN[kind], testErr = prep(testAllDSN[kind])
+		if testErr != nil {
 			return
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -15,7 +15,7 @@ type Session struct {
 // NewSession instantiates a new Session using a certain kind of
 // data store. The dsn or data source name (DSN) is used to connect.
 // The format of the DSN depends on the kind of store used.
-func NewSession(kind stores.StoreKind, dsn string) (*Session, error) {
+func NewSession(kind kolektor.StoreKind, dsn string) (*Session, error) {
 	ses := &Session{}
 	var err error
 

--- a/session_mysql_test.go
+++ b/session_mysql_test.go
@@ -5,7 +5,7 @@ package kolekto
 import (
 	"testing"
 
-	"github.com/golistic/kolekto/stores"
+	"github.com/golistic/kolekto/kolektor"
 	"github.com/golistic/kolekto/stores/dbmysql"
 
 	"github.com/geertjanvdk/xkit/xt"
@@ -13,7 +13,7 @@ import (
 
 func TestNew(t *testing.T) {
 	t.Run("test MySQL", func(t *testing.T) {
-		session, err := NewSession(stores.MySQL, testAllDSN[stores.MySQL])
+		session, err := NewSession(kolektor.MySQL, testAllDSN[kolektor.MySQL])
 		xt.OK(t, err)
 		_, ok := session.store.(*dbmysql.Store)
 		xt.Assert(t, ok, "expected *dbmysql.Store")
@@ -21,7 +21,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestCollection_Store_mysql(t *testing.T) {
-	session, err := NewSession(stores.MySQL, testAllDSN[stores.MySQL])
+	session, err := NewSession(kolektor.MySQL, testAllDSN[kolektor.MySQL])
 	xt.OK(t, err)
 
 	testCollection_Store(t, session)

--- a/session_pgsql_test.go
+++ b/session_pgsql_test.go
@@ -7,7 +7,7 @@ package kolekto
 import (
 	"testing"
 
-	"github.com/golistic/kolekto/stores"
+	"github.com/golistic/kolekto/kolektor"
 	"github.com/golistic/kolekto/stores/dbpgsql"
 
 	"github.com/geertjanvdk/xkit/xt"
@@ -15,7 +15,7 @@ import (
 
 func TestNew_pgsql(t *testing.T) {
 	t.Run("test PostgreSQL using pgxpool", func(t *testing.T) {
-		session, err := NewSession(stores.PgSQL, testAllDSN[stores.PgSQL])
+		session, err := NewSession(kolektor.PgSQL, testAllDSN[kolektor.PgSQL])
 		xt.OK(t, err)
 		_, ok := session.store.(*dbpgsql.Store)
 		xt.Assert(t, ok, "expected *dbpgsql.Store")
@@ -23,7 +23,7 @@ func TestNew_pgsql(t *testing.T) {
 }
 
 func TestCollection_Store_pgsql(t *testing.T) {
-	session, err := NewSession(stores.PgSQL, testAllDSN[stores.PgSQL])
+	session, err := NewSession(kolektor.PgSQL, testAllDSN[kolektor.PgSQL])
 	xt.OK(t, err)
 
 	testCollection_Store(t, session)

--- a/session_test.go
+++ b/session_test.go
@@ -22,6 +22,39 @@ func (b Book) CollectionName() string {
 	return "books"
 }
 
+func (b Book) Indexes(kind kolektor.StoreKind) []kolektor.Index {
+	m := map[kolektor.StoreKind][]kolektor.Index{
+		kolektor.MySQL: {
+			{
+				Name:       "uq_books_isbn13",
+				Unique:     true,
+				Expression: "((CAST(data->>'$.isbn13' AS CHAR(20))))",
+			},
+			{
+				Name:       "ix_books_title",
+				Expression: "((CAST(data->>'$.title' AS CHAR(200))))",
+			},
+		},
+		kolektor.PgSQL: {
+			{
+				Name:       "uq_books_isbn13",
+				Unique:     true,
+				Expression: "((data->>'isbn13'))",
+			},
+			{
+				Name:       "ix_books_title",
+				Expression: "((data->>'title'))",
+			},
+		},
+	}
+
+	if res, have := m[kind]; have {
+		return res
+	}
+
+	return nil
+}
+
 func testCollection_Store(t *testing.T, session *Session) {
 	t.Run("store object and retrieve it", func(t *testing.T) {
 		book := &Book{

--- a/stores/dbmysql/indexing.go
+++ b/stores/dbmysql/indexing.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package dbmysql
+
+import (
+	"context"
+	"crypto/md5"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/golistic/kolekto/kolektor"
+	"github.com/golistic/xstrings"
+)
+
+func md5sum[T string | []byte](value T) string {
+	sum := md5.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func addIndexes(conn *sql.Conn, idxer kolektor.Indexer, tableName string) error {
+	var alters []string
+
+	haveIndexes, err := getIndexes(conn, tableName)
+	if err != nil {
+		return err
+	}
+
+	var wantIndexes []string
+	for _, idx := range idxer.Indexes(kolektor.MySQL) {
+		wantIndexes = append(wantIndexes, idx.Name)
+		unique := ""
+		if idx.Unique {
+			unique = "UNIQUE"
+		}
+
+		exprSum := md5sum(idx.Expression)
+		if haveHash, have := haveIndexes[idx.Name]; have {
+			if exprSum == haveHash {
+				// index did not change; skip
+				continue
+			} else {
+				// index changed; recreate it by dropping it first
+				alters = append(alters, fmt.Sprintf("DROP INDEX %s", idx.Name))
+			}
+		}
+
+		alters = append(alters, fmt.Sprintf("ADD %s INDEX %s %s COMMENT 'kolekto#%s'",
+			unique, idx.Name, idx.Expression, exprSum))
+	}
+
+	for name := range haveIndexes {
+		if xstrings.Search(wantIndexes, name) == -1 {
+			alters = append(alters, fmt.Sprintf("DROP INDEX %s", name))
+		}
+	}
+
+	if len(alters) > 0 {
+		dml := "ALTER TABLE " + tableName + " " + strings.Join(alters, ", ")
+		if _, err := conn.ExecContext(context.Background(), dml); err != nil {
+			return fmt.Errorf("failed creating indexes for %s (%w)", tableName, err)
+		}
+	}
+	return nil
+}
+
+func getIndexes(conn *sql.Conn, tableName string) (map[string]string, error) {
+	q := "SELECT INDEX_NAME, INDEX_COMMENT FROM INFORMATION_SCHEMA.STATISTICS" +
+		" WHERE TABLE_SCHEMA = DATABASE() AND" +
+		" TABLE_NAME = ? AND INDEX_NAME <> 'PRIMARY' AND INDEX_COMMENT LIKE 'kolekto#%'"
+
+	rows, err := conn.QueryContext(context.Background(), q, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting indexes (%w)", err)
+	}
+
+	indexes := map[string]string{}
+
+	for rows.Next() {
+		var name string
+		var comment string
+		if err := rows.Scan(&name, &comment); err != nil {
+			return nil, fmt.Errorf("failed getting indexes (%w)", err)
+		}
+		parts := strings.Split(comment, "#")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("failed getting indexes (bad index comment)")
+		}
+		indexes[name] = parts[1]
+	}
+
+	return indexes, nil
+}

--- a/stores/dbmysql/main_test.go
+++ b/stores/dbmysql/main_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package dbmysql
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golistic/kolekto/internal/ytest"
+)
+
+// following defaults assume Docker containers are started using the
+// Docker Compose configuration found in _support/docker-compose
+const defaultMySQLDSN = "root:mysql@tcp(localhost:3360)/kolekto_test_store"
+
+var (
+	testExitCode int
+	testErr      error
+	testDSN      string
+)
+
+func testTearDown() {
+	if testErr != nil {
+		fmt.Println(testErr)
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	defer func() { os.Exit(testExitCode) }()
+	defer testTearDown()
+
+	if v, have := os.LookupEnv("TEST_MYSQL_DSN"); have {
+		testDSN = v
+	} else {
+		testDSN = defaultMySQLDSN
+	}
+
+	testDSN, testErr = ytest.PrepareMySQL(testDSN)
+	if testErr != nil {
+		return
+	}
+
+	testExitCode = m.Run()
+}

--- a/stores/dbmysql/store_test.go
+++ b/stores/dbmysql/store_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package dbmysql
+
+import (
+	"testing"
+
+	"github.com/geertjanvdk/xkit/xt"
+	"github.com/golistic/kolekto/kolektor"
+)
+
+type Book struct {
+	kolektor.Model
+	ISBN13  string   `json:"isbn13"`
+	Title   string   `json:"title"`
+	Authors []string `json:"authors,omitempty"`
+
+	fuIndex          func() map[kolektor.StoreKind][]kolektor.Index
+	fuCollectionName func() string
+}
+
+var _ kolektor.Modeler = &Book{}
+
+func (b Book) CollectionName() string {
+	return b.fuCollectionName()
+}
+
+func (b Book) Indexes(kind kolektor.StoreKind) []kolektor.Index {
+	m := b.fuIndex()
+
+	if res, have := m[kind]; have {
+		return res
+	}
+
+	return nil
+}
+
+func TestStore_InitCollection(t *testing.T) {
+	s, err := New(testDSN)
+	xt.OK(t, err)
+	store := s.(*Store)
+
+	expIndex1 := []string{"uq_books_isbn13", "((CAST(data->>'$.isbn13' AS CHAR(20))))"}
+	expIndex2 := []string{"ix_books_title", "((CAST(data->>'$.title' AS CHAR(200))))"}
+
+	t.Run("add indexes", func(t *testing.T) {
+		fuCollectionName := func() string {
+			return "books_239d9k3d"
+		}
+
+		book := &Book{}
+		book.fuCollectionName = fuCollectionName
+
+		book.fuIndex = func() map[kolektor.StoreKind][]kolektor.Index {
+			return map[kolektor.StoreKind][]kolektor.Index{
+				kolektor.MySQL: {
+					{
+						Name:       expIndex1[0],
+						Unique:     true,
+						Expression: expIndex1[1],
+					},
+					{
+						Name:       expIndex2[0],
+						Expression: expIndex2[1],
+					},
+				},
+			}
+		}
+
+		xt.OK(t, store.InitCollection(book))
+		indexes, err := getIndexes(store.mustSQLConn(), book.CollectionName())
+		xt.OK(t, err)
+		xt.Eq(t, 2, len(indexes))
+		exprSum, _ := indexes[expIndex1[0]]
+		xt.Eq(t, md5sum(expIndex1[1]), exprSum)
+		exprSum, _ = indexes[expIndex2[0]]
+		xt.Eq(t, md5sum(expIndex2[1]), exprSum)
+
+		t.Run("remove index", func(t *testing.T) {
+			book := &Book{}
+			book.fuCollectionName = fuCollectionName
+
+			book.fuIndex = func() map[kolektor.StoreKind][]kolektor.Index {
+				return map[kolektor.StoreKind][]kolektor.Index{
+					kolektor.MySQL: {
+						{
+							Name:       expIndex1[0],
+							Unique:     true,
+							Expression: expIndex1[1],
+						},
+					},
+				}
+			}
+
+			xt.OK(t, store.InitCollection(book))
+			indexes, err := getIndexes(store.mustSQLConn(), book.CollectionName())
+			xt.OK(t, err)
+			xt.Eq(t, 1, len(indexes))
+			exprSum, _ := indexes[expIndex1[0]]
+			xt.Eq(t, md5sum(expIndex1[1]), exprSum)
+		})
+
+		t.Run("change index", func(t *testing.T) {
+			book := &Book{}
+			book.fuCollectionName = fuCollectionName
+
+			// change length of char
+			expIndex1 := []string{"uq_books_isbn13", "((CAST(data->>'$.isbn13' AS CHAR(40))))"}
+			book.fuIndex = func() map[kolektor.StoreKind][]kolektor.Index {
+				return map[kolektor.StoreKind][]kolektor.Index{
+					kolektor.MySQL: {
+						{
+							Name:       expIndex1[0],
+							Unique:     true,
+							Expression: expIndex1[1],
+						},
+					},
+				}
+			}
+
+			xt.OK(t, store.InitCollection(book))
+			indexes, err := getIndexes(store.mustSQLConn(), book.CollectionName())
+			xt.OK(t, err)
+			xt.Eq(t, 1, len(indexes))
+			exprSum, _ := indexes[expIndex1[0]]
+			xt.Eq(t, md5sum(expIndex1[1]), exprSum)
+		})
+	})
+}

--- a/stores/dbpgsql/indexing.go
+++ b/stores/dbpgsql/indexing.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package dbpgsql
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/golistic/kolekto/kolektor"
+	"github.com/golistic/xstrings"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+func md5sum[T string | []byte](value T) string {
+	sum := md5.Sum([]byte(value))
+	return hex.EncodeToString(sum[:])
+}
+
+func addIndexes(conn *pgxpool.Conn, idxer kolektor.Indexer, tableName string) error {
+	haveIndexes, err := getIndexes(conn, tableName)
+	if err != nil {
+		return err
+	}
+
+	var wantIndexes []string
+	for _, idx := range idxer.Indexes(kolektor.PgSQL) {
+		wantIndexes = append(wantIndexes, idx.Name)
+		unique := ""
+		if idx.Unique {
+			unique = "UNIQUE"
+		}
+
+		exprSum := md5sum(idx.Expression)
+		if haveHash, have := haveIndexes[idx.Name]; have {
+			if exprSum == haveHash {
+				// index did not change; skip
+				continue
+			} else {
+				// index changed; recreate it by dropping it first
+				dml := fmt.Sprintf("DROP INDEX %s", idx.Name)
+				if _, err := conn.Exec(context.Background(), dml); err != nil {
+					return fmt.Errorf("failed dropping index %s (%w)", idx.Name, err)
+				}
+			}
+		}
+
+		dml := fmt.Sprintf("CREATE %s INDEX %s ON %s %s; COMMENT ON INDEX %s IS 'kolekto#%s'",
+			unique, idx.Name, tableName, idx.Expression, idx.Name, exprSum)
+
+		if _, err := conn.Exec(context.Background(), dml); err != nil {
+			return fmt.Errorf("failed creating index %s (%w)", idx.Name, err)
+		}
+	}
+
+	for name := range haveIndexes {
+		if xstrings.Search(wantIndexes, name) == -1 {
+			dml := fmt.Sprintf("DROP INDEX %s", name)
+			if _, err := conn.Exec(context.Background(), dml); err != nil {
+				return fmt.Errorf("failed dropping index %s (%w)", name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func getIndexes(conn *pgxpool.Conn, tableName string) (map[string]string, error) {
+	q := "SELECT indexrelname, description" +
+		" FROM pg_catalog.pg_stat_all_indexes as idx" +
+		" LEFT JOIN pg_catalog.pg_description ON idx.indexrelid = pg_description.objoid" +
+		" WHERE relname = $1 AND schemaname = \"current_schema\"() AND" +
+		" description LIKE 'kolekto#%'"
+
+	rows, err := conn.Query(context.Background(), q, tableName)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting indexes (%w)", err)
+	}
+
+	indexes := map[string]string{}
+
+	for rows.Next() {
+		var name string
+		var comment string
+		if err := rows.Scan(&name, &comment); err != nil {
+			return nil, fmt.Errorf("failed getting indexes (%w)", err)
+		}
+		parts := strings.Split(comment, "#")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("failed getting indexes (bad index comment)")
+		}
+		indexes[name] = parts[1]
+	}
+
+	return indexes, nil
+}

--- a/stores/dbpgsql/main_test.go
+++ b/stores/dbpgsql/main_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package dbpgsql
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/golistic/kolekto/internal/ytest"
+)
+
+// following defaults assume Docker containers are started using the
+// Docker Compose configuration found in _support/docker-compose
+const defaultPgSQLDSN = "postgres://postgres:postgres@localhost:5438/kolekto_test_store"
+
+var (
+	testExitCode int
+	testErr      error
+	testDSN      string
+)
+
+func testTearDown() {
+	if testErr != nil {
+		fmt.Println(testErr)
+		os.Exit(1)
+	}
+}
+
+func TestMain(m *testing.M) {
+	defer func() { os.Exit(testExitCode) }()
+	defer testTearDown()
+
+	if v, have := os.LookupEnv("TEST_PGSQL_DSN"); have {
+		testDSN = v
+	} else {
+		testDSN = defaultPgSQLDSN
+	}
+
+	testDSN, testErr = ytest.PreparePostgreSQL(testDSN)
+	if testErr != nil {
+		return
+	}
+
+	testExitCode = m.Run()
+}

--- a/stores/dbpgsql/store_test.go
+++ b/stores/dbpgsql/store_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package dbpgsql
+
+import (
+	"testing"
+
+	"github.com/geertjanvdk/xkit/xt"
+	"github.com/golistic/kolekto/kolektor"
+)
+
+type Book struct {
+	kolektor.Model
+	ISBN13  string   `json:"isbn13"`
+	Title   string   `json:"title"`
+	Authors []string `json:"authors,omitempty"`
+
+	fuIndex          func() map[kolektor.StoreKind][]kolektor.Index
+	fuCollectionName func() string
+}
+
+var _ kolektor.Modeler = &Book{}
+
+func (b Book) CollectionName() string {
+	return b.fuCollectionName()
+}
+
+func (b Book) Indexes(kind kolektor.StoreKind) []kolektor.Index {
+	m := b.fuIndex()
+
+	if res, have := m[kind]; have {
+		return res
+	}
+
+	return nil
+}
+
+func TestStore_InitCollection(t *testing.T) {
+	s, err := New(testDSN)
+	xt.OK(t, err)
+	store := s.(*Store)
+
+	expIndex1 := []string{"uq_books_isbn13", "((data->>'isbn13'))"}
+	expIndex2 := []string{"ix_books_title", "((data->>'title'))"}
+
+	t.Run("add indexes", func(t *testing.T) {
+		fuCollectionName := func() string {
+			return "books_239d9k3d"
+		}
+
+		book := &Book{}
+		book.fuCollectionName = fuCollectionName
+
+		book.fuIndex = func() map[kolektor.StoreKind][]kolektor.Index {
+			return map[kolektor.StoreKind][]kolektor.Index{
+				kolektor.PgSQL: {
+					{
+						Name:       expIndex1[0],
+						Unique:     true,
+						Expression: expIndex1[1],
+					},
+					{
+						Name:       expIndex2[0],
+						Expression: expIndex2[1],
+					},
+				},
+			}
+		}
+
+		xt.OK(t, store.InitCollection(book))
+		indexes, err := getIndexes(store.mustConn(), book.CollectionName())
+		xt.OK(t, err)
+		xt.Eq(t, 2, len(indexes))
+		exprSum, _ := indexes[expIndex1[0]]
+		xt.Eq(t, md5sum(expIndex1[1]), exprSum)
+		exprSum, _ = indexes[expIndex2[0]]
+		xt.Eq(t, md5sum(expIndex2[1]), exprSum)
+
+		t.Run("remove index", func(t *testing.T) {
+			book := &Book{}
+			book.fuCollectionName = fuCollectionName
+
+			book.fuIndex = func() map[kolektor.StoreKind][]kolektor.Index {
+				return map[kolektor.StoreKind][]kolektor.Index{
+					kolektor.PgSQL: {
+						{
+							Name:       expIndex1[0],
+							Unique:     true,
+							Expression: expIndex1[1],
+						},
+					},
+				}
+			}
+
+			xt.OK(t, store.InitCollection(book))
+			indexes, err := getIndexes(store.mustConn(), book.CollectionName())
+			xt.OK(t, err)
+			xt.Eq(t, 1, len(indexes))
+			exprSum, _ := indexes[expIndex1[0]]
+			xt.Eq(t, md5sum(expIndex1[1]), exprSum)
+		})
+
+		t.Run("change index", func(t *testing.T) {
+			book := &Book{}
+			book.fuCollectionName = fuCollectionName
+
+			// change length of char
+			expIndex1 := []string{"uq_books_isbn13", "((data->>'isbn13foo'))"}
+			book.fuIndex = func() map[kolektor.StoreKind][]kolektor.Index {
+				return map[kolektor.StoreKind][]kolektor.Index{
+					kolektor.PgSQL: {
+						{
+							Name:       expIndex1[0],
+							Unique:     true,
+							Expression: expIndex1[1],
+						},
+					},
+				}
+			}
+
+			xt.OK(t, store.InitCollection(book))
+			indexes, err := getIndexes(store.mustConn(), book.CollectionName())
+			xt.OK(t, err)
+			xt.Eq(t, 1, len(indexes))
+			exprSum, _ := indexes[expIndex1[0]]
+			xt.Eq(t, md5sum(expIndex1[1]), exprSum)
+		})
+	})
+}

--- a/stores/registry.go
+++ b/stores/registry.go
@@ -6,10 +6,10 @@ import (
 	"github.com/golistic/kolekto/kolektor"
 )
 
-var registry = map[StoreKind]func(dsn string) (kolektor.Storer, error){}
+var registry = map[kolektor.StoreKind]func(dsn string) (kolektor.Storer, error){}
 
 // New instantiated a certain kind of store using dsn for connecting.
-func New(kind StoreKind, dsn string) (kolektor.Storer, error) {
+func New(kind kolektor.StoreKind, dsn string) (kolektor.Storer, error) {
 	store, err := registry[kind](dsn)
 	if err != nil {
 		return nil, err
@@ -19,6 +19,6 @@ func New(kind StoreKind, dsn string) (kolektor.Storer, error) {
 
 // Register registers a kind of store mapping it with it initialization
 // function.
-func Register(kind StoreKind, fn func(dsn string) (kolektor.Storer, error)) {
+func Register(kind kolektor.StoreKind, fn func(dsn string) (kolektor.Storer, error)) {
 	registry[kind] = fn
 }


### PR DESCRIPTION
We add the possibility to define indexes, unique or not, per Model
per store kind. Newly defined indexes will be added automatically. When
the expression changes, they will be replaced, and when not any longer
needed, removed.
These operations happen everytime the Collection is retrieved.

Tests have been added for both supported stores MySQL and PostgreSQL.